### PR TITLE
feat: configurable deployment strategy for RWO volume support

### DIFF
--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
   - name: Richardo-C
     url: https://github.com/RichardoC
 type: application
-version: 0.0.4
+version: 0.0.5
 appVersion: v1.75.5-stable
 description: |
   The 'litellm' chart provides a solution for deploying LiteLLM proxy with helm.
@@ -12,5 +12,5 @@ description: |
   It is a refined version of the original [litellm](https://github.com/BerriAI/litellm/tree/main/deploy/charts/litellm-helm) chart.
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: all surge of 100 percent during rollout, to mitigate the slower deployments issue
+    - kind: added
+      description: configurable deploymentStrategy to support Recreate for RWO volume users

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -9,9 +9,12 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.deploymentStrategy.type }}
+    {{- if eq .Values.deploymentStrategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: 100%
+      maxSurge: {{ .Values.deploymentStrategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deploymentStrategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "litellm.selectorLabels" . | nindent 6 }}

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -30,6 +30,16 @@ podDisruptionBudget:
   create: false
   minAvailable: 1
 
+# Deployment strategy. Use Recreate when mounting RWO (ReadWriteOnce) volumes
+# to avoid multi-attach errors during rollouts — RollingUpdate would attempt to
+# bind the volume to the new pod while the old pod still holds it.
+# type: RollingUpdate | Recreate
+deploymentStrategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 100%
+    maxUnavailable: 0
+
 # Default environment variables for the proxy. They are put into the environment configMap.
 env:
   LITELLM_LOG: "ERROR"


### PR DESCRIPTION
**Problem**

 The chart hardcoded `strategy: type: RollingUpdate`, which causes a multi-attach error when using RWO (`ReadWriteOnce`) PersistentVolumeClaims. During a rolling rollout both old and new  pods may be scheduled on different nodes simultaneously, but a RWO volume can only be bound to one node at a time — the new pod gets stuck waiting for the volume to be released.

 **Solution**

 Expose `deploymentStrategy` in `values.yaml` so users can switch to `Recreate` when their storage class requires it. The `Recreate` strategy terminates all existing pods before new ones  are created, ensuring the volume is detached before the rollout proceeds.

 Default behaviour is unchanged (`RollingUpdate` with `maxSurge: 100%`).

 **Usage**

 ```yaml
 # values.yaml — for RWO volumes
 deploymentStrategy:
   type: Recreate
 ```

 ```yaml
 # values.yaml — default (no change required)
 deploymentStrategy:
   type: RollingUpdate
   rollingUpdate:
     maxSurge: 100%
     maxUnavailable: 0
 ```

 **Changes**

 - `charts/litellm/values.yaml` — added `deploymentStrategy` block with defaults
 - `charts/litellm/templates/deployment.yaml` — strategy section reads from values; `rollingUpdate` parameters are only emitted when `type: RollingUpdate`
 - `charts/litellm/Chart.yaml` — bumped chart version to `0.0.5`