### PR TITLE
feat(startupProbe): default startupProbe to gate readiness

### DIFF
--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
   - name: Richardo-C
     url: https://github.com/RichardoC
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: v1.75.5-stable
 description: |
   The 'litellm' chart provides a solution for deploying LiteLLM proxy with helm.

--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -14,3 +14,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: configDirExtraFiles to ship custom files (e.g. callback/hook .py modules) into the proxy config directory /etc/litellm via a chart-managed ConfigMap projected alongside config.yaml, with automatic Deployment rollout on change
+    - kind: added
+      description: startupProbe to gate liveness/readiness during slow container startup, defaulting to a 3-minute window

--- a/charts/litellm/README.md
+++ b/charts/litellm/README.md
@@ -1,6 +1,6 @@
 # litellm
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.75.5-stable](https://img.shields.io/badge/AppVersion-v1.75.5--stable-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.75.5-stable](https://img.shields.io/badge/AppVersion-v1.75.5--stable-informational?style=flat-square)
 
 The 'litellm' chart provides a solution for deploying LiteLLM proxy with helm.
 
@@ -99,6 +99,10 @@ proxy_config:
 | service.port | int | `4000` |  |
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.create | bool | `false` |  |
+| startupProbe.failureThreshold | int | `18` |  |
+| startupProbe.httpGet.path | string | `"/health/readiness"` |  |
+| startupProbe.httpGet.port | string | `"http"` |  |
+| startupProbe.periodSeconds | int | `10` |  |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           lifecycle:
             preStop:
               exec:

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -92,6 +92,12 @@ readinessProbe:
   httpGet:
     path: /health/readiness
     port: http
+startupProbe:
+  httpGet:
+    path: /health/readiness
+    port: http
+  failureThreshold: 18
+  periodSeconds: 10
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## Summary

Default `startupProbe` field to the chart. When set, it's rendered into the container.

## Motivation

Slow-starting workloads (e.g. litellm with `NUM_WORKERS>1`?) can be killed by the liveness probe before the proxy finishes booting. The Kubernetes-native fix is a `startupProbe` that gates liveness/readiness until the container is fully up. Without chart support, deployers are forced to slacken `livenessProbe.initialDelaySeconds` for the steady-state, which then hides real deploy failures.

Tested local templating / apply --dry-run=client.