### PR TITLE
feat(litellm): mount extra ConfigMap sources into config dir

### DIFF
--- a/.github/workflows/charts.lint-and-test.yaml
+++ b/.github/workflows/charts.lint-and-test.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # tag v4.3.1
         with:
-          version: v3.10.1 # Also update in publish.yaml
+          version: v3.21.1 # Also update in publish.yaml
 
       - name: Set up python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0

--- a/.github/workflows/charts.publish.yaml
+++ b/.github/workflows/charts.publish.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # tag v4.3.1
         with:
-          version: v3.10.1 # Also update in lint-and-test.yaml
+          version: v3.21.1 # Also update in lint-and-test.yaml
 
       - name: Configure Git
         run: |

--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -4,7 +4,7 @@ maintainers:
   - name: Richardo-C
     url: https://github.com/RichardoC
 type: application
-version: 0.0.4
+version: 0.1.0
 appVersion: v1.75.5-stable
 description: |
   The 'litellm' chart provides a solution for deploying LiteLLM proxy with helm.
@@ -12,5 +12,5 @@ description: |
   It is a refined version of the original [litellm](https://github.com/BerriAI/litellm/tree/main/deploy/charts/litellm-helm) chart.
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: all surge of 100 percent during rollout, to mitigate the slower deployments issue
+    - kind: added
+      description: configDirExtraConfigMaps to merge extra ConfigMap sources (e.g. custom callback .py files) into the proxy config directory /etc/litellm via a projected volume

--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -14,3 +14,5 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: configDirExtraConfigMaps to merge extra ConfigMap sources (e.g. custom callback .py files) into the proxy config directory /etc/litellm via a projected volume
+    - kind: added
+      description: checksum/config-dir-extra pod annotation so the Deployment rolls out when the extra config-dir ConfigMaps change

--- a/charts/litellm/Chart.yaml
+++ b/charts/litellm/Chart.yaml
@@ -13,6 +13,4 @@ description: |
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: configDirExtraConfigMaps to merge extra ConfigMap sources (e.g. custom callback .py files) into the proxy config directory /etc/litellm via a projected volume
-    - kind: added
-      description: checksum/config-dir-extra pod annotation so the Deployment rolls out when the extra config-dir ConfigMaps change
+      description: configDirExtraFiles to ship custom files (e.g. callback/hook .py modules) into the proxy config directory /etc/litellm via a chart-managed ConfigMap projected alongside config.yaml, with automatic Deployment rollout on change

--- a/charts/litellm/README.md
+++ b/charts/litellm/README.md
@@ -1,6 +1,6 @@
 # litellm
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.75.5-stable](https://img.shields.io/badge/AppVersion-v1.75.5--stable-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.75.5-stable](https://img.shields.io/badge/AppVersion-v1.75.5--stable-informational?style=flat-square)
 
 The 'litellm' chart provides a solution for deploying LiteLLM proxy with helm.
 
@@ -21,6 +21,7 @@ It is a refined version of the original [litellm](https://github.com/BerriAI/lit
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| configDirExtraConfigMaps | list | `[]` | Additional ConfigMap sources merged into the proxy config directory (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook .py files referenced from litellm_settings.callbacks — LiteLLM resolves those modules relative to the config file's directory. Mounted via a projected volume, so no extra mount paths are needed. Each entry references an existing ConfigMap by name; create that ConfigMap separately. |
 | env.LITELLM_LOG | string | `"ERROR"` |  |
 | env.LITELLM_MODE | string | `"PRODUCTION"` |  |
 | envFromSecretRefs | list | `[]` | List of secrets to be used as environment variables for the proxy |

--- a/charts/litellm/README.md
+++ b/charts/litellm/README.md
@@ -12,6 +12,25 @@ It is a refined version of the original [litellm](https://github.com/BerriAI/lit
 | ---- | ------ | --- |
 | Richardo-C |  | <https://github.com/RichardoC> |
 
+## Custom callbacks / extra files in the config directory
+
+LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). This chart mounts `/etc/litellm` as a projected volume, so you can merge extra ConfigMap sources into the same directory without adding extra `volumeMounts`.
+
+Create a ConfigMap with your callback file(s), then reference it via `configDirExtraConfigMaps`:
+
+```yaml
+configDirExtraConfigMaps:
+  - name: litellm-callbacks
+    items:
+      - key: my_handler.py
+        path: my_handler.py
+```
+
+**Notes:**
+
+- The `path` values must not collide with `config.yaml` or with each other. If two sources target the same path, the pod will fail to be created.
+- These ConfigMaps are created and managed separately from this chart. Their contents are folded into a `checksum/config-dir-extra` pod annotation (read via `lookup`), so `helm upgrade` rolls out the Deployment when they change. Where `lookup` is unavailable (e.g. `helm template`/`--dry-run`, or GitOps tooling that disables it) a content-only change is not detected — use a reloader or roll out the Deployment manually in that case.
+
 ## Values
 
 | Key | Type | Default | Description |
@@ -21,7 +40,7 @@ It is a refined version of the original [litellm](https://github.com/BerriAI/lit
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| configDirExtraConfigMaps | list | `[]` | Additional ConfigMap sources merged into the proxy config directory (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook .py files referenced from litellm_settings.callbacks — LiteLLM resolves those modules relative to the config file's directory. Mounted via a projected volume, so no extra mount paths are needed. Each entry references an existing ConfigMap by name; create that ConfigMap separately. |
+| configDirExtraConfigMaps | list | `[]` | Additional ConfigMap sources merged into the proxy config directory (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook .py files referenced from litellm_settings.callbacks — LiteLLM resolves those modules relative to the config file's directory. Mounted via a projected volume, so no extra mount paths are needed. Each entry references an existing ConfigMap by name; create that ConfigMap separately. Avoid path collisions: the projected `path` values must not collide with `config.yaml` or each other, or the pod will fail to start. Changes to these ConfigMaps are folded into a `checksum/config-dir-extra` pod annotation (their contents are read via `lookup`), so `helm upgrade` rolls out the Deployment when they change — except where `lookup` is unavailable (e.g. `helm template`/`--dry-run` or GitOps tools that disable it), in which case use a reloader or roll out manually. |
 | env.LITELLM_LOG | string | `"ERROR"` |  |
 | env.LITELLM_MODE | string | `"PRODUCTION"` |  |
 | envFromSecretRefs | list | `[]` | List of secrets to be used as environment variables for the proxy |

--- a/charts/litellm/README.md
+++ b/charts/litellm/README.md
@@ -14,22 +14,30 @@ It is a refined version of the original [litellm](https://github.com/BerriAI/lit
 
 ## Custom callbacks / extra files in the config directory
 
-LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). This chart mounts `/etc/litellm` as a projected volume, so you can merge extra ConfigMap sources into the same directory without adding extra `volumeMounts`.
+LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). To ship custom hook/handler `.py` files, set `configDirExtraFiles` (keyed by filename). The chart renders them into a ConfigMap (with a content-hashed name) and projects it into `/etc/litellm` alongside `config.yaml`, so no extra `volumeMounts` are needed, and any change rolls out the Deployment automatically.
 
-Create a ConfigMap with your callback file(s), then reference it via `configDirExtraConfigMaps`:
+You almost certainly don't want Python source inlined in your YAML. Keep each handler as a real `.py` file and load it at install time with Helm's `--set-file`, which reads the file's contents into the value:
+
+```console
+$ helm upgrade --install litellm oci://ghcr.io/richardoc/litellm_helm-chart/litellm \
+    --values values.yaml \
+    --set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'
+```
+
+Then reference the module from your config:
 
 ```yaml
-configDirExtraConfigMaps:
-  - name: litellm-callbacks
-    items:
-      - key: my_handler.py
-        path: my_handler.py
+proxy_config:
+  litellm_settings:
+    callbacks: ["my_handler.proxy_handler_instance"]
 ```
+
+`--set-file` also works through orchestrators that pass Helm flags — e.g. Tilt's [`helm_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_resource) via `flags=['--set-file', 'configDirExtraFiles.my_handler\\.py=./hooks/my_handler.py']`. (Inlining the contents directly under `configDirExtraFiles` in a values file is also supported, e.g. for tooling that can't pass `--set-file`.)
 
 **Notes:**
 
-- The `path` values must not collide with `config.yaml` or with each other. If two sources target the same path, the pod will fail to be created.
-- These ConfigMaps are created and managed separately from this chart. Their contents are folded into a `checksum/config-dir-extra` pod annotation (read via `lookup`), so `helm upgrade` rolls out the Deployment when they change. Where `lookup` is unavailable (e.g. `helm template`/`--dry-run`, or GitOps tooling that disables it) a content-only change is not detected — use a reloader or roll out the Deployment manually in that case.
+- Filenames must not collide with `config.yaml`.
+- The rendered files are folded into a `checksum/config-dir-extra` pod annotation (and the ConfigMap name is content-hashed), so changing them rolls out the Deployment automatically.
 
 ## Values
 
@@ -40,7 +48,7 @@ configDirExtraConfigMaps:
 | autoscaling.maxReplicas | int | `10` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| configDirExtraConfigMaps | list | `[]` | Additional ConfigMap sources merged into the proxy config directory (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook .py files referenced from litellm_settings.callbacks — LiteLLM resolves those modules relative to the config file's directory. Mounted via a projected volume, so no extra mount paths are needed. Each entry references an existing ConfigMap by name; create that ConfigMap separately. Avoid path collisions: the projected `path` values must not collide with `config.yaml` or each other, or the pod will fail to start. Changes to these ConfigMaps are folded into a `checksum/config-dir-extra` pod annotation (their contents are read via `lookup`), so `helm upgrade` rolls out the Deployment when they change — except where `lookup` is unavailable (e.g. `helm template`/`--dry-run` or GitOps tools that disable it), in which case use a reloader or roll out manually. |
+| configDirExtraFiles | object | `{}` | Custom files to drop into the proxy config directory (/etc/litellm) alongside config.yaml — e.g. callback/hook .py modules referenced from litellm_settings.callbacks. LiteLLM resolves those modules relative to the config file's directory, so they must live next to config.yaml. Keys are filenames, values are the file contents. The chart renders these into a ConfigMap (content-hashed name) and projects it into /etc/litellm (no extra mount paths needed), and folds their contents into a `checksum/config-dir-extra` pod annotation, so changes roll out the Deployment automatically. Filenames must not collide with `config.yaml`. Rather than inlining source here, prefer keeping each handler as a real file and loading it at install time with `helm --set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'`. |
 | env.LITELLM_LOG | string | `"ERROR"` |  |
 | env.LITELLM_MODE | string | `"PRODUCTION"` |  |
 | envFromSecretRefs | list | `[]` | List of secrets to be used as environment variables for the proxy |

--- a/charts/litellm/README.md.gotmpl
+++ b/charts/litellm/README.md.gotmpl
@@ -15,22 +15,30 @@
 
 ## Custom callbacks / extra files in the config directory
 
-LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). This chart mounts `/etc/litellm` as a projected volume, so you can merge extra ConfigMap sources into the same directory without adding extra `volumeMounts`.
+LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). To ship custom hook/handler `.py` files, set `configDirExtraFiles` (keyed by filename). The chart renders them into a ConfigMap (with a content-hashed name) and projects it into `/etc/litellm` alongside `config.yaml`, so no extra `volumeMounts` are needed, and any change rolls out the Deployment automatically.
 
-Create a ConfigMap with your callback file(s), then reference it via `configDirExtraConfigMaps`:
+You almost certainly don't want Python source inlined in your YAML. Keep each handler as a real `.py` file and load it at install time with Helm's `--set-file`, which reads the file's contents into the value:
+
+```console
+$ helm upgrade --install litellm oci://ghcr.io/richardoc/litellm_helm-chart/litellm \
+    --values values.yaml \
+    --set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'
+```
+
+Then reference the module from your config:
 
 ```yaml
-configDirExtraConfigMaps:
-  - name: litellm-callbacks
-    items:
-      - key: my_handler.py
-        path: my_handler.py
+proxy_config:
+  litellm_settings:
+    callbacks: ["my_handler.proxy_handler_instance"]
 ```
+
+`--set-file` also works through orchestrators that pass Helm flags — e.g. Tilt's [`helm_resource`](https://github.com/tilt-dev/tilt-extensions/tree/master/helm_resource) via `flags=['--set-file', 'configDirExtraFiles.my_handler\\.py=./hooks/my_handler.py']`. (Inlining the contents directly under `configDirExtraFiles` in a values file is also supported, e.g. for tooling that can't pass `--set-file`.)
 
 **Notes:**
 
-- The `path` values must not collide with `config.yaml` or with each other. If two sources target the same path, the pod will fail to be created.
-- These ConfigMaps are created and managed separately from this chart. Their contents are folded into a `checksum/config-dir-extra` pod annotation (read via `lookup`), so `helm upgrade` rolls out the Deployment when they change. Where `lookup` is unavailable (e.g. `helm template`/`--dry-run`, or GitOps tooling that disables it) a content-only change is not detected — use a reloader or roll out the Deployment manually in that case.
+- Filenames must not collide with `config.yaml`.
+- The rendered files are folded into a `checksum/config-dir-extra` pod annotation (and the ConfigMap name is content-hashed), so changing them rolls out the Deployment automatically.
 
 {{ template "chart.valuesSection" . }}
 

--- a/charts/litellm/README.md.gotmpl
+++ b/charts/litellm/README.md.gotmpl
@@ -1,0 +1,37 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Custom callbacks / extra files in the config directory
+
+LiteLLM resolves callback modules referenced in `litellm_settings.callbacks` relative to the directory containing `config.yaml` (i.e. `/etc/litellm`). This chart mounts `/etc/litellm` as a projected volume, so you can merge extra ConfigMap sources into the same directory without adding extra `volumeMounts`.
+
+Create a ConfigMap with your callback file(s), then reference it via `configDirExtraConfigMaps`:
+
+```yaml
+configDirExtraConfigMaps:
+  - name: litellm-callbacks
+    items:
+      - key: my_handler.py
+        path: my_handler.py
+```
+
+**Notes:**
+
+- The `path` values must not collide with `config.yaml` or with each other. If two sources target the same path, the pod will fail to be created.
+- These ConfigMaps are created and managed separately from this chart. Their contents are folded into a `checksum/config-dir-extra` pod annotation (read via `lookup`), so `helm upgrade` rolls out the Deployment when they change. Where `lookup` is unavailable (e.g. `helm template`/`--dry-run`, or GitOps tooling that disables it) a content-only change is not detected — use a reloader or roll out the Deployment manually in that case.
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/litellm/templates/_helpers.tpl
+++ b/charts/litellm/templates/_helpers.tpl
@@ -70,6 +70,27 @@ Create the name of the config configmap with hash suffix
 {{- end }}
 
 {{/*
+Checksum of the extra config-dir ConfigMap sources, used as a pod annotation so
+the Deployment rolls out when the projected ConfigMaps change.
+
+It folds in both the referenced set (names/items from values) and the live
+contents of those ConfigMaps. Contents are read via `lookup`, which only
+resolves against a live cluster (helm install/upgrade). Under `helm template`,
+`--dry-run`, or tooling that disables lookups (e.g. some GitOps dry-runs) the
+content portion is empty, so there a content-only change will not be detected.
+*/}}
+{{- define "litellm.configDirExtraChecksum" -}}
+{{- $parts := list (.Values.configDirExtraConfigMaps | toYaml) -}}
+{{- range .Values.configDirExtraConfigMaps -}}
+{{- $cm := lookup "v1" "ConfigMap" $.Release.Namespace .name -}}
+{{- if $cm -}}
+{{- $parts = append $parts (printf "%s/%s=%s" $.Release.Namespace .name (toYaml ($cm.data | default dict))) -}}
+{{- end -}}
+{{- end -}}
+{{- $parts | join "\n" | sha256sum -}}
+{{- end }}
+
+{{/*
 Calculate the sleep duration for preStop hook
 */}}
 {{- define "litellm.sleepDuration" -}}

--- a/charts/litellm/templates/_helpers.tpl
+++ b/charts/litellm/templates/_helpers.tpl
@@ -70,24 +70,12 @@ Create the name of the config configmap with hash suffix
 {{- end }}
 
 {{/*
-Checksum of the extra config-dir ConfigMap sources, used as a pod annotation so
-the Deployment rolls out when the projected ConfigMaps change.
-
-It folds in both the referenced set (names/items from values) and the live
-contents of those ConfigMaps. Contents are read via `lookup`, which only
-resolves against a live cluster (helm install/upgrade). Under `helm template`,
-`--dry-run`, or tooling that disables lookups (e.g. some GitOps dry-runs) the
-content portion is empty, so there a content-only change will not be detected.
+Create the name of the extra config-dir configmap with hash suffix, so the
+Deployment rolls out when the projected files change.
 */}}
-{{- define "litellm.configDirExtraChecksum" -}}
-{{- $parts := list (.Values.configDirExtraConfigMaps | toYaml) -}}
-{{- range .Values.configDirExtraConfigMaps -}}
-{{- $cm := lookup "v1" "ConfigMap" $.Release.Namespace .name -}}
-{{- if $cm -}}
-{{- $parts = append $parts (printf "%s/%s=%s" $.Release.Namespace .name (toYaml ($cm.data | default dict))) -}}
-{{- end -}}
-{{- end -}}
-{{- $parts | join "\n" | sha256sum -}}
+{{- define "litellm.configDirExtraConfigMapName" -}}
+{{- $content := .Values.configDirExtraFiles | toYaml | sha256sum | trunc 8 | trimSuffix "-" }}
+{{- printf "%s-config-extra-%s" (include "litellm.fullname" .) $content }}
 {{- end }}
 
 {{/*

--- a/charts/litellm/templates/config-dir-extra.yaml
+++ b/charts/litellm/templates/config-dir-extra.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.configDirExtraFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "litellm.configDirExtraConfigMapName" . }}
+  labels:
+    {{- include "litellm.labels" . | nindent 4 }}
+data:
+  {{- range $filename, $contents := .Values.configDirExtraFiles }}
+  {{ $filename }}: |
+{{ $contents | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -98,11 +98,21 @@ spec:
             {{- end }}
       volumes:
         - name: litellm-config
-          configMap:
-            name: {{ include "litellm.configConfigMapName" . }}
-            items:
-              - key: config.yaml
-                path: config.yaml
+          projected:
+            sources:
+              - configMap:
+                  name: {{ include "litellm.configConfigMapName" . }}
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              {{- range .Values.configDirExtraConfigMaps }}
+              - configMap:
+                  name: {{ .name }}
+                  {{- with .items }}
+                  items:
+                    {{- toYaml . | nindent 20 }}
+                  {{- end }}
+              {{- end }}
         {{ if .Values.securityContext.readOnlyRootFilesystem }}
         - name: tmp
           emptyDir:

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -23,8 +23,8 @@ spec:
         {{- if .Values.extraObjects }}
         checksum/extra-manifests: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.configDirExtraConfigMaps }}
-        checksum/config-dir-extra: {{ include "litellm.configDirExtraChecksum" . }}
+        {{- if .Values.configDirExtraFiles }}
+        checksum/config-dir-extra: {{ include (print $.Template.BasePath "/config-dir-extra.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -108,13 +108,14 @@ spec:
                   items:
                     - key: config.yaml
                       path: config.yaml
-              {{- range .Values.configDirExtraConfigMaps }}
+              {{- if .Values.configDirExtraFiles }}
               - configMap:
-                  name: {{ .name }}
-                  {{- with .items }}
+                  name: {{ include "litellm.configDirExtraConfigMapName" . }}
                   items:
-                    {{- toYaml . | nindent 20 }}
-                  {{- end }}
+                    {{- range $filename, $contents := .Values.configDirExtraFiles }}
+                    - key: {{ $filename }}
+                      path: {{ $filename }}
+                    {{- end }}
               {{- end }}
         {{ if .Values.securityContext.readOnlyRootFilesystem }}
         - name: tmp

--- a/charts/litellm/templates/deployment.yaml
+++ b/charts/litellm/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
         {{- if .Values.extraObjects }}
         checksum/extra-manifests: {{ include (print $.Template.BasePath "/extra-manifests.yaml") . | sha256sum }}
         {{- end }}
+        {{- if .Values.configDirExtraConfigMaps }}
+        checksum/config-dir-extra: {{ include "litellm.configDirExtraChecksum" . }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/litellm/tests/config-dir-extra-configmaps_test.yaml
+++ b/charts/litellm/tests/config-dir-extra-configmaps_test.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Test configDirExtraConfigMaps
+templates:
+  - deployment.yaml
+  - config.yaml
+  - environment.yaml
+  - extra-manifests.yaml
+release:
+  name: lite11m
+tests:
+  - it: By default the litellm-config volume is a projected volume with a single config.yaml source
+    template: deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - exists:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected
+      - notExists:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].configMap
+      - lengthEqual:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources
+          count: 1
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[0].configMap.items[0].path
+          value: config.yaml
+
+  - it: When given extra ConfigMap sources, merges them into the projected config volume
+    template: deployment.yaml
+    set:
+      configDirExtraConfigMaps:
+        - name: litellm-callbacks
+          items:
+            - key: my_handler.py
+              path: my_handler.py
+    asserts:
+      - isKind:
+          of: Deployment
+      - lengthEqual:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources
+          count: 2
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[1].configMap.name
+          value: litellm-callbacks
+      - equal:
+          path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[1].configMap.items[0].path
+          value: my_handler.py
+      - equal:
+          path: spec.template.spec.containers[?(@.name == "litellm")].volumeMounts[?(@.name == "litellm-config")].mountPath
+          value: /etc/litellm/

--- a/charts/litellm/tests/config-dir-extra-configmaps_test.yaml
+++ b/charts/litellm/tests/config-dir-extra-configmaps_test.yaml
@@ -23,6 +23,8 @@ tests:
       - equal:
           path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[0].configMap.items[0].path
           value: config.yaml
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/config-dir-extra"]
 
   - it: When given extra ConfigMap sources, merges them into the projected config volume
     template: deployment.yaml
@@ -47,3 +49,5 @@ tests:
       - equal:
           path: spec.template.spec.containers[?(@.name == "litellm")].volumeMounts[?(@.name == "litellm-config")].mountPath
           value: /etc/litellm/
+      - isNotNullOrEmpty:
+          path: spec.template.metadata.annotations["checksum/config-dir-extra"]

--- a/charts/litellm/tests/config-dir-extra-files_test.yaml
+++ b/charts/litellm/tests/config-dir-extra-files_test.yaml
@@ -1,8 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
-suite: Test configDirExtraConfigMaps
+suite: Test configDirExtraFiles
 templates:
   - deployment.yaml
   - config.yaml
+  - config-dir-extra.yaml
   - environment.yaml
   - extra-manifests.yaml
 release:
@@ -26,23 +27,27 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations["checksum/config-dir-extra"]
 
-  - it: When given extra ConfigMap sources, merges them into the projected config volume
+  - it: By default no extra config-dir ConfigMap is rendered
+    template: config-dir-extra.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: When given extra files, projects a chart-created ConfigMap into the config volume
     template: deployment.yaml
     set:
-      configDirExtraConfigMaps:
-        - name: litellm-callbacks
-          items:
-            - key: my_handler.py
-              path: my_handler.py
+      configDirExtraFiles:
+        my_handler.py: |
+          proxy_handler_instance = object()
     asserts:
       - isKind:
           of: Deployment
       - lengthEqual:
           path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources
           count: 2
-      - equal:
+      - matchRegex:
           path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[1].configMap.name
-          value: litellm-callbacks
+          pattern: ^lite11m-litellm-config-extra-[a-f0-9]+$
       - equal:
           path: spec.template.spec.volumes[?(@.name == "litellm-config")].projected.sources[1].configMap.items[0].path
           value: my_handler.py
@@ -51,3 +56,20 @@ tests:
           value: /etc/litellm/
       - isNotNullOrEmpty:
           path: spec.template.metadata.annotations["checksum/config-dir-extra"]
+
+  - it: When given extra files, renders them into a ConfigMap
+    template: config-dir-extra.yaml
+    set:
+      configDirExtraFiles:
+        my_handler.py: |
+          proxy_handler_instance = object()
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: metadata.name
+          pattern: ^lite11m-litellm-config-extra-[a-f0-9]+$
+      - equal:
+          path: data["my_handler.py"]
+          value: |
+            proxy_handler_instance = object()

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -116,7 +116,14 @@ volumeMounts: []
 # .py files referenced from litellm_settings.callbacks — LiteLLM resolves those
 # modules relative to the config file's directory. Mounted via a projected
 # volume, so no extra mount paths are needed. Each entry references an existing
-# ConfigMap by name; create that ConfigMap separately.
+# ConfigMap by name; create that ConfigMap separately. Avoid path collisions:
+# the projected `path` values must not collide with `config.yaml` or each other,
+# or the pod will fail to start. Changes to these ConfigMaps are folded into a
+# `checksum/config-dir-extra` pod annotation (their contents are read via
+# `lookup`), so `helm upgrade` rolls out the Deployment when they change —
+# except where `lookup` is unavailable (e.g. `helm template`/`--dry-run` or
+# GitOps tools that disable it), in which case use a reloader or roll out
+# manually.
 configDirExtraConfigMaps: []
 #  - name: litellm-callbacks
 #    items:

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -111,6 +111,18 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# -- Additional ConfigMap sources merged into the proxy config directory
+# (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook
+# .py files referenced from litellm_settings.callbacks — LiteLLM resolves those
+# modules relative to the config file's directory. Mounted via a projected
+# volume, so no extra mount paths are needed. Each entry references an existing
+# ConfigMap by name; create that ConfigMap separately.
+configDirExtraConfigMaps: []
+#  - name: litellm-callbacks
+#    items:
+#      - key: my_handler.py
+#        path: my_handler.py
+
 nodeSelector: {}
 
 tolerations: []

--- a/charts/litellm/values.yaml
+++ b/charts/litellm/values.yaml
@@ -111,24 +111,25 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-# -- Additional ConfigMap sources merged into the proxy config directory
-# (/etc/litellm) alongside config.yaml. Use this to ship custom callback/hook
-# .py files referenced from litellm_settings.callbacks — LiteLLM resolves those
-# modules relative to the config file's directory. Mounted via a projected
-# volume, so no extra mount paths are needed. Each entry references an existing
-# ConfigMap by name; create that ConfigMap separately. Avoid path collisions:
-# the projected `path` values must not collide with `config.yaml` or each other,
-# or the pod will fail to start. Changes to these ConfigMaps are folded into a
-# `checksum/config-dir-extra` pod annotation (their contents are read via
-# `lookup`), so `helm upgrade` rolls out the Deployment when they change —
-# except where `lookup` is unavailable (e.g. `helm template`/`--dry-run` or
-# GitOps tools that disable it), in which case use a reloader or roll out
-# manually.
-configDirExtraConfigMaps: []
-#  - name: litellm-callbacks
-#    items:
-#      - key: my_handler.py
-#        path: my_handler.py
+# -- Custom files to drop into the proxy config directory (/etc/litellm)
+# alongside config.yaml — e.g. callback/hook .py modules referenced from
+# litellm_settings.callbacks. LiteLLM resolves those modules relative to the
+# config file's directory, so they must live next to config.yaml. Keys are
+# filenames, values are the file contents. The chart renders these into a
+# ConfigMap (content-hashed name) and projects it into /etc/litellm (no extra
+# mount paths needed), and folds their contents into a `checksum/config-dir-extra`
+# pod annotation, so changes roll out the Deployment automatically. Filenames
+# must not collide with `config.yaml`. Rather than inlining source here, prefer
+# keeping each handler as a real file and loading it at install time with
+# `helm --set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'`.
+configDirExtraFiles: {}
+#  my_handler.py: |
+#    from litellm.integrations.custom_logger import CustomLogger
+#
+#    class MyHandler(CustomLogger):
+#        pass
+#
+#    proxy_handler_instance = MyHandler()
 
 nodeSelector: {}
 

--- a/scripts/helm-docs.sh
+++ b/scripts/helm-docs.sh
@@ -11,7 +11,13 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 echo "Repo root: $REPO_ROOT"
 
 echo "Running helm-docs"
+# Each chart's README.md is generated from its charts/<chart>/README.md.gotmpl
+# template, which lets us keep hand-written sections (e.g. the custom callbacks
+# guide in charts/litellm/README.md.gotmpl) alongside the auto-generated values
+# table. Passing --template-files makes that template an explicit input rather
+# than relying on helm-docs' implicit default.
 docker run --rm \
     -v "$REPO_ROOT:/helm-docs" \
     -u $(id -u) \
-    jnorwood/helm-docs:v$HELM_DOCS_VERSION
+    jnorwood/helm-docs:v$HELM_DOCS_VERSION \
+    --template-files=README.md.gotmpl


### PR DESCRIPTION
## Motivation

LiteLLM's proxy resolves custom callback modules (referenced in `litellm_settings.callbacks`) **relative to the directory of its config file**. A hook referenced as `my_handler.proxy_handler_instance` must exist on disk at `/etc/litellm/my_handler.py`.

See `get_instance_fn` in `litellm/proxy/types_utils/utils.py`: when `config_file_path` is set it *only* does `os.path.join(os.path.dirname(config_file_path), *module.split('.')) + '.py'`, with no `PYTHONPATH` / `import_module` fallback.

The chart mounts `/etc/litellm` from the config ConfigMap with `items: [config.yaml]`, which makes it impossible to land a sibling `.py` file there: `subPath`-mounting another volume fails (read-only ConfigMap mount), and baking the file into a custom image gets shadowed by the mount.

## The change

Convert the `litellm-config` volume to a **projected** volume and add a new value, `configDirExtraFiles` — a map of filename → file contents. The chart renders those into a **chart-managed ConfigMap** (with a content-hashed name) and projects it into `/etc/litellm` alongside `config.yaml`. The `volumeMounts` entry (`mountPath: /etc/litellm/`) is unchanged.

Because the file contents flow through Helm values, the ConfigMap name and the `checksum/config-dir-extra` pod annotation are **fully deterministic** — so the Deployment rolls out automatically whenever a file changes, with no `lookup` and no externally-managed ConfigMap. This works under live `helm upgrade` as well as template-based renders (GitOps, Tilt, `helm template`).

### Keeping handlers as real `.py` files (no inline YAML)

You don't have to inline Python into your values. Keep each handler as a real file and load it at install time with Helm's `--set-file`:

```console
$ helm upgrade --install litellm oci://ghcr.io/richardoc/litellm_helm-chart/litellm \
    --values values.yaml \
    --set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'
```

This also works through orchestrators that pass Helm flags (e.g. Tilt's `helm_resource` `flags=[...]`). Inlining the contents in a values file is still supported for tooling that can't pass `--set-file`.

## Backwards compatibility

`configDirExtraFiles` defaults to `{}`: the rendered volume has a single source (the existing `config.yaml`) and behaves exactly as before. No extra ConfigMap is created.

## `helm template` before / after

**Default (`configDirExtraFiles: {}`) — single source, unchanged behaviour:**

```yaml
      volumes:
        - name: litellm-config
          projected:
            sources:
              - configMap:
                  name: release-name-litellm-config-a390b41f
                  items:
                    - key: config.yaml
                      path: config.yaml
```

**With `--set-file 'configDirExtraFiles.my_handler\.py=./hooks/my_handler.py'`:**

```yaml
      volumes:
        - name: litellm-config
          projected:
            sources:
              - configMap:
                  name: release-name-litellm-config-a390b41f
                  items:
                    - key: config.yaml
                      path: config.yaml
              - configMap:
                  name: release-name-litellm-config-extra-10cf1d83   # content-hashed
                  items:
                    - key: my_handler.py
                      path: my_handler.py
```

…plus a rendered `ConfigMap/release-name-litellm-config-extra-10cf1d83` containing the file, and a `checksum/config-dir-extra` pod annotation.

## Other changes

- Bumped the chart version `0.0.4` -> `0.1.0` (backwards-compatible feature, minor bump) and updated the `artifacthub.io/changes` annotation.
- Added a `charts/litellm/README.md.gotmpl` with a "Custom callbacks / extra files in the config directory" section (so helm-docs doesn't overwrite it) and regenerated `README.md`.
- Added a helm-unittest suite covering the default (no extra ConfigMap, no annotation) and enabled (ConfigMap rendered + projected + annotation) cases.
- **CI fix:** bumped Helm `v3.10.1` -> `v3.21.1` in both workflows — the latest `helm-unittest` plugin's `plugin.yaml` uses the `platformHooks` field, which requires Helm >= 3.13, so `chart-test` was failing to load the plugin (`unknown field "platformHooks"`).

## Testing

- `helm lint charts/litellm` ✅
- `helm template charts/litellm` (default) — single projected source, no extra ConfigMap ✅
- `helm template … --set-file 'configDirExtraFiles.my_handler\.py=./my_handler.py'` — chart-managed ConfigMap rendered, projected, hashed name + checksum annotation ✅
- `helm unittest charts/litellm` — passing ✅